### PR TITLE
初回起動時にデータベース作成するSQLの誤りを修正 #21

### DIFF
--- a/src/Hinata.Core/Data/Database.cs
+++ b/src/Hinata.Core/Data/Database.cs
@@ -43,7 +43,7 @@ WHERE
                         if (reader.HasRows) return;
                     }
 
-                    command.CommandText = string.Format("CREATE DATABASE [{0}] Japanese_CI_AS", databaseName);
+                    command.CommandText = string.Format("CREATE DATABASE [{0}] COLLATE Japanese_CI_AS", databaseName);
                     command.ExecuteNonQuery();
                 }
 


### PR DESCRIPTION
CREATE DATABASEの照合順序の指定にCOLLATE句が抜けていたので追加しました。
