### PR TITLE
記事本文のスタイルを調整

### DIFF
--- a/src/Hinata.WebApp/Content/bootstrap/variables.custom.less
+++ b/src/Hinata.WebApp/Content/bootstrap/variables.custom.less
@@ -53,10 +53,10 @@
 @font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
 @font-size-small:         11px;//ceil((@font-size-base * 0.85)); // ~12px
 
-@font-size-h1:            floor((@font-size-base * 2.6)); // ~36px
-@font-size-h2:            floor((@font-size-base * 2.15)); // ~30px
-@font-size-h3:            ceil((@font-size-base * 1.7)); // ~24px
-@font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px
+@font-size-h1:            floor((@font-size-base * 2.0)); // ~36px
+@font-size-h2:            floor((@font-size-base * 1.8)); // ~30px
+@font-size-h3:            ceil((@font-size-base * 1.6)); // ~24px
+@font-size-h4:            ceil((@font-size-base * 1.4)); // ~18px
 @font-size-h5:            @font-size-base;
 @font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
 
@@ -835,8 +835,8 @@
 //
 //##
 
-@code-color:                  #c7254e;
-@code-bg:                     #f9f2f4;
+@code-color:                  #000000;
+@code-bg:                     #F5F5F5;
 
 @kbd-color:                   #fff;
 @kbd-bg:                      #333;

--- a/src/Hinata.WebApp/Content/hinata/item-viewer.less
+++ b/src/Hinata.WebApp/Content/hinata/item-viewer.less
@@ -1,10 +1,11 @@
-﻿@font-size-base: 14px;
-@font-size-h1: floor((@font-size-base * 2.5));
-@font-size-h2: floor((@font-size-base * 2.0));
-@font-size-h3: ceil((@font-size-base * 1.75));
-@font-size-h4: ceil((@font-size-base * 1.25));
-@font-size-h5: @font-size-base;
-@font-size-h6: ceil((@font-size-base * 0.85));
+﻿// Use variables.custom.less
+// @font-size-base: 14px;
+// @font-size-h1: floor((@font-size-base * 2.5));
+// @font-size-h2: floor((@font-size-base * 2.0));
+// @font-size-h3: ceil((@font-size-base * 1.75));
+// @font-size-h4: ceil((@font-size-base * 1.25));
+// @font-size-h5: @font-size-base;
+// @font-size-h6: ceil((@font-size-base * 0.85));
 
 .item-viewer {
     color: #333;
@@ -13,13 +14,30 @@
     line-height: 1.6;
     word-wrap: break-word;
 
+    h1, h2, h3, h4, h5, h6 {
+        position: relative;
+        margin-top: 30px;
+        margin-bottom: 15px;
+        line-height: 1.1;
+        font-weight: bold;
+        padding-bottom: 4px;
+        border-bottom: 1px solid #eee;
+    }
+
     h1 {
         font-size: @font-size-h1;
-        margin: 0.67em 0;
+        margin: 2em 0 0.68em;
+        border-bottom: 2px solid #c8b4b4;
+
+        &:first-child {
+            margin-top: 0.68em;
+        }
     }
 
     h2 {
         font-size: @font-size-h2;
+
+        border-bottom-width: 2px;
     }
 
     h3 {
@@ -36,15 +54,6 @@
 
     h6 {
         font-size: @font-size-h6;
-    }
-
-    h1, h2, h3, h4, h5, h6 {
-        position: relative;
-        margin-top: 30px;
-        margin-bottom: 15px;
-        line-height: 1.1;
-        font-weight: bold;
-        border-bottom: 1px solid #eee;
     }
 
     hr {
@@ -67,9 +76,17 @@
         }
     }
 
+    ul {
+        margin-left: 1.5em;
+    }
+    ol {
+        margin-left: 2em;
+    }
+
     ul, ol {
         margin-top: 0;
         margin-bottom: 0;
+        padding-left: 0;
 
         ol {
             list-style-type: lower-roman;
@@ -77,6 +94,11 @@
             ol {
                 list-style-type: lower-alpha;
             }
+        }
+
+        ul, ol {
+            margin-left: 2.5em;
+            margin-bottom: 0;
         }
     }
 
@@ -123,8 +145,8 @@
     pre {
         word-wrap: normal;
         overflow: auto;
-        margin-top: 0;
-        margin-bottom: 0;
+        margin-top: 16px;
+        margin-bottom: 16px;
         padding: 14px;
         border: 0;
 


### PR DESCRIPTION
・見出しサイズを小さめに変更
・見出し（h1、h2）の下線を目立つよう調整
・見出し（h1）の上マージンを空けるよう調整
・コードブロックの前後に余白を取るように修正
・インラインコードが目立ちすぎないよう調整
・箇条書きの左端のラインが浮かないよう調整
