### PR TITLE
「.」を含むタグの登録を制限する #20

### DIFF
--- a/src/Hinata.WebApp/Models/DraftModels.cs
+++ b/src/Hinata.WebApp/Models/DraftModels.cs
@@ -87,6 +87,11 @@ namespace Hinata.Models
                     validationResults.Add(new ValidationResult("使用できない文字を使ったタグが存在します。", new[] { "TagInlineString" }));
                 }
 
+                if (tagNames.Any(name => name.EndsWith(".")))
+                {
+                    validationResults.Add(new ValidationResult("「.」で終わるタグ名をつけることはできません。", new[] { "TagInlineString" }));
+                }
+
                 if (tags.Any(x => x.Name.Length > 32))
                 {
                     validationResults.Add(new ValidationResult("一つのタグの長さはは最大32文字までです。", new[] { "TagInlineString" }));

--- a/src/Hinata.WebApp/Web.config
+++ b/src/Hinata.WebApp/Web.config
@@ -96,7 +96,7 @@
     <handlers>
       <add name="LessAssetHandler" path="*.less" verb="GET" type="BundleTransformer.Less.HttpHandlers.LessAssetHandler, BundleTransformer.Less" resourceType="File" preCondition="" />
       <add name="MarkdownTextHandler" path="*/raw/*.md" verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-      <add name="TagNameHandler" path="/tag/*" verb="GET" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <add name="TagNameHandler" path="/tag/*.*" verb="GET" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
   <bundleTransformer xmlns="http://tempuri.org/BundleTransformer.Configuration.xsd">


### PR DESCRIPTION
「.」で始まる、「.」を中に含むタグ名はweb.configのhandlerの記述を変更することで対応。
「.」で終わるタグ名は登録できないようにする。ModelのValidation内にチェックする処理を追加。
