### PR TITLE
下書き一覧のプレビューにCSSが適用されていなかったので修正 #34

### DIFF
--- a/src/Hinata.WebApp/Views/Draft/_Preview.cshtml
+++ b/src/Hinata.WebApp/Views/Draft/_Preview.cshtml
@@ -9,7 +9,7 @@
             <h2 class="panel-title">@Model.Title</h2>
             @Html.DisplayFor(m => Model.ItemTags)
         </div>
-        <div class="panel-body item-view markdown-body">
+        <div class="panel-body item-viewer">
             @Html.Raw(@Model.Html)
         </div>
     </div>


### PR DESCRIPTION
classの指定間違い。Azure版の時のclassをつけていました。
