### PR TITLE
HTMLタグを含む記事を修正すると不要な要求検証の結果、例外が発生する問題を修正 #78

### DIFF
--- a/src/Hinata.WebApp/Models/DraftModels.cs
+++ b/src/Hinata.WebApp/Models/DraftModels.cs
@@ -41,6 +41,7 @@ namespace Hinata.Models
         [Display(Name = "本文")]
         public string Body { get; set; }
 
+        [AllowHtml]
         public string PublishedBody { get; set; }
 
         [PlaceHolder("いつ")]


### PR DESCRIPTION
PublishedBodyにAllowHtml属性を付けましたが、DIFFの比較元をAjaxで取得するようにした時は、ReadOnly属性の方が良い。
